### PR TITLE
记录每个请求的 Token 消耗(预估)

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "axios": "^1.3.4",
-    "chatgpt": "^5.1.2",
+    "chatgpt": "^5.2.2",
     "dotenv": "^16.0.3",
     "esno": "^0.16.3",
     "express": "^4.18.2",

--- a/service/pnpm-lock.yaml
+++ b/service/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^1.3.4
     version: 1.3.4
   chatgpt:
-    specifier: ^5.1.2
-    version: 5.1.2
+    specifier: ^5.2.2
+    version: 5.2.2
   dotenv:
     specifier: ^16.0.3
     version: 16.0.3
@@ -715,8 +715,10 @@ packages:
       - supports-color
     dev: false
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -976,15 +978,15 @@ packages:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: true
 
-  /chatgpt@5.1.2:
-    resolution: {integrity: sha512-b/NnDQHDOpouK+gmhUCKcKuvnKEh+DotwXlP6Qgw1mqmkcfVl9Wt3/3noT8jbGJpMEpFOfzexXn5Rehpea1N0w==}
+  /chatgpt@5.2.2:
+    resolution: {integrity: sha512-6HVueHj7ghJtcsBHi8CfXCC5fbCXJMc29NSGluTcg/2yLo0Jla3Wm/dlcz3cIb+7KVBKD5b6Qz5bVu8XFEF7Sg==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
       '@dqbd/tiktoken': 1.0.2
       cac: 6.7.14
       conf: 11.0.1
-      eventsource-parser: 0.0.5
+      eventsource-parser: 1.0.0
       keyv: 4.5.2
       p-timeout: 6.1.1
       quick-lru: 6.1.1
@@ -1059,7 +1061,7 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       atomically: 2.0.1
       debounce-fn: 5.1.2
       dot-prop: 7.2.0
@@ -1782,9 +1784,9 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /eventsource-parser@0.0.5:
-    resolution: {integrity: sha512-BAq82bC3ZW9fPYYZlofXBOAfbpmDzXIOsj+GOehQwgTUYsQZ6HtHs6zuRtge7Ph8OhS6lNH1kJF8q9dj17RcmA==}
-    engines: {node: '>=12'}
+  /eventsource-parser@1.0.0:
+    resolution: {integrity: sha512-9jgfSCa3dmEme2ES3mPByGXfgZ87VbP97tng1G2nWwWx6bV2nYxm2AWCrbQjXToSe+yYlqaZNtxffR9IeQr95g==}
+    engines: {node: '>=14.18'}
     dev: false
 
   /execa@5.1.1:

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -6,7 +6,7 @@ import type { ChatContext, ChatMessage } from './chatgpt'
 import { chatConfig, chatReplyProcess, currentModel, initApi } from './chatgpt'
 import { auth } from './middleware/auth'
 import { clearConfigCache, getCacheConfig, getOriginConfig } from './storage/config'
-import type { ChatOptions, Config, MailConfig, SiteConfig, UserInfo } from './storage/model'
+import type { ChatOptions, Config, MailConfig, SiteConfig, UsageResponse, UserInfo } from './storage/model'
 import { Status } from './storage/model'
 import {
   clearChat,
@@ -22,6 +22,7 @@ import {
   getUser,
   getUserById,
   insertChat,
+  insertChatUsage,
   renameChatRoom,
   updateChat,
   updateConfig,
@@ -230,10 +231,13 @@ router.post('/chat', auth, async (req, res) => {
       if (regenerate && message.options.messageId) {
         const previousResponse = message.previousResponse || []
         previousResponse.push({ response: message.response, messageId: message.options.messageId })
-        await updateChat(message._id, response.data.text, response.data.id, previousResponse)
+        await updateChat(message._id as unknown as string, response.data.text, response.data.id, previousResponse)
       } else {
-        await updateChat(message._id, response.data.text, response.data.id)
+        await updateChat(message._id as unknown as string, response.data.text, response.data.id)
       }
+
+      if (response.data.usage)
+        await insertChatUsage(req.headers.userId as string, roomId, uuid, response.data.id, response.data.detail.usage as UsageResponse)
     }
     res.send(response)
   }
@@ -264,10 +268,13 @@ router.post('/chat-process', [auth, limiter], async (req, res) => {
       if (regenerate && message.options.messageId) {
         const previousResponse = message.previousResponse || []
         previousResponse.push({ response: message.response, messageId: message.options.messageId })
-        await updateChat(message._id, result.data.text, result.data.id, previousResponse)
+        await updateChat(message._id as unknown as string, result.data.text, result.data.id, previousResponse)
       } else {
-        await updateChat(message._id, result.data.text, result.data.id)
+        await updateChat(message._id as unknown as string, result.data.text, result.data.id)
       }
+
+      if (result.data.detail.usage)
+        await insertChatUsage(req.headers.userId as string, roomId, uuid, result.data.id, result.data.detail.usage as UsageResponse)
     }
   }
   catch (error) {

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -230,14 +230,27 @@ router.post('/chat', auth, async (req, res) => {
     if (response.status === 'Success') {
       if (regenerate && message.options.messageId) {
         const previousResponse = message.previousResponse || []
-        previousResponse.push({ response: message.response, messageId: message.options.messageId })
-        await updateChat(message._id as unknown as string, response.data.text, response.data.id, previousResponse)
-      } else {
-        await updateChat(message._id as unknown as string, response.data.text, response.data.id)
+        previousResponse.push({ response: message.response, options: message.options })
+        await updateChat(message._id as unknown as string,
+          response.data.text,
+          response.data.id,
+          response.data.detail.usage as UsageResponse,
+          previousResponse)
+      }
+      else {
+        await updateChat(message._id as unknown as string,
+          response.data.text,
+          response.data.id,
+          response.data.detail.usage as UsageResponse)
       }
 
-      if (response.data.usage)
-        await insertChatUsage(req.headers.userId as string, roomId, uuid, response.data.id, response.data.detail.usage as UsageResponse)
+      if (response.data.usage) {
+        await insertChatUsage(req.headers.userId as string,
+          roomId,
+          message._id,
+          response.data.id,
+          response.data.detail.usage as UsageResponse)
+      }
     }
     res.send(response)
   }
@@ -267,14 +280,27 @@ router.post('/chat-process', [auth, limiter], async (req, res) => {
     if (result.status === 'Success') {
       if (regenerate && message.options.messageId) {
         const previousResponse = message.previousResponse || []
-        previousResponse.push({ response: message.response, messageId: message.options.messageId })
-        await updateChat(message._id as unknown as string, result.data.text, result.data.id, previousResponse)
-      } else {
-        await updateChat(message._id as unknown as string, result.data.text, result.data.id)
+        previousResponse.push({ response: message.response, options: message.options })
+        await updateChat(message._id as unknown as string,
+          result.data.text,
+          result.data.id,
+          result.data.detail.usage as UsageResponse,
+          previousResponse)
+      }
+      else {
+        await updateChat(message._id as unknown as string,
+          result.data.text,
+          result.data.id,
+          result.data.detail.usage as UsageResponse)
       }
 
-      if (result.data.detail.usage)
-        await insertChatUsage(req.headers.userId as string, roomId, uuid, result.data.id, result.data.detail.usage as UsageResponse)
+      if (result.data.detail.usage) {
+        await insertChatUsage(req.headers.userId as string,
+          roomId,
+          message._id,
+          result.data.id,
+          result.data.detail.usage as UsageResponse)
+      }
     }
   }
   catch (error) {

--- a/service/src/storage/model.ts
+++ b/service/src/storage/model.ts
@@ -46,6 +46,10 @@ export class ChatOptions {
   parentMessageId?: string
   messageId?: string
   conversationId?: string
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  estimated?: boolean
   constructor(parentMessageId?: string, messageId?: string, conversationId?: string) {
     this.parentMessageId = parentMessageId
     this.messageId = messageId
@@ -55,7 +59,7 @@ export class ChatOptions {
 
 export class previousResponse {
   response: string
-  messageId: string
+  options: ChatOptions
 }
 
 export class ChatInfo {
@@ -88,23 +92,23 @@ export class ChatUsage {
   _id: ObjectId
   userId: string
   roomId: number
-  uuid: number
+  chatId: ObjectId
   messageId: string
   promptTokens: number
   completionTokens: number
   totalTokens: number
   estimated: boolean
   dateTime: number
-  constructor(userId: string, roomId: number, uuid: number, messageId: string, usage: UsageResponse) {
+  constructor(userId: string, roomId: number, chatId: ObjectId, messageId: string, usage: UsageResponse) {
     this.userId = userId
     this.roomId = roomId
-    this.uuid = uuid
+    this.chatId = chatId
     this.messageId = messageId
-    this.dateTime = new Date().getTime()
     this.promptTokens = usage.prompt_tokens
     this.completionTokens = usage.completion_tokens
     this.totalTokens = usage.total_tokens
     this.estimated = usage.estimated
+    this.dateTime = new Date().getTime()
   }
 }
 

--- a/service/src/storage/model.ts
+++ b/service/src/storage/model.ts
@@ -77,6 +77,37 @@ export class ChatInfo {
   }
 }
 
+export class UsageResponse {
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  estimated: boolean
+}
+
+export class ChatUsage {
+  _id: ObjectId
+  userId: string
+  roomId: number
+  uuid: number
+  messageId: string
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  estimated: boolean
+  dateTime: number
+  constructor(userId: string, roomId: number, uuid: number, messageId: string, usage: UsageResponse) {
+    this.userId = userId
+    this.roomId = roomId
+    this.uuid = uuid
+    this.messageId = messageId
+    this.dateTime = new Date().getTime()
+    this.promptTokens = usage.prompt_tokens
+    this.completionTokens = usage.completion_tokens
+    this.totalTokens = usage.total_tokens
+    this.estimated = usage.estimated
+  }
+}
+
 export class Config {
   constructor(
     public _id: ObjectId,

--- a/service/src/storage/mongo.ts
+++ b/service/src/storage/mongo.ts
@@ -30,10 +30,17 @@ export async function getChat(roomId: number, uuid: number) {
   return await chatCol.findOne({ roomId, uuid })
 }
 
-export async function updateChat(chatId: string, response: string, messageId: string, previousResponse?: []) {
+export async function updateChat(chatId: string, response: string, messageId: string, usage: UsageResponse, previousResponse?: []) {
   const query = { _id: new ObjectId(chatId) }
   const update = {
-    $set: { 'response': response, 'options.messageId': messageId },
+    $set: {
+      'response': response,
+      'options.messageId': messageId,
+      'options.prompt_tokens': usage.prompt_tokens,
+      'options.completion_tokens': usage.completion_tokens,
+      'options.total_tokens': usage.total_tokens,
+      'options.estimated': usage.estimated,
+    },
   }
 
   if (previousResponse)
@@ -42,8 +49,8 @@ export async function updateChat(chatId: string, response: string, messageId: st
   await chatCol.updateOne(query, update)
 }
 
-export async function insertChatUsage(userId: string, roomId: number, uuid: number, messageId: string, usage: UsageResponse) {
-  const chatUsage = new ChatUsage(userId, roomId, uuid, messageId, usage)
+export async function insertChatUsage(userId: string, roomId: number, chatId: ObjectId, messageId: string, usage: UsageResponse) {
+  const chatUsage = new ChatUsage(userId, roomId, chatId, messageId, usage)
   await usageCol.insertOne(chatUsage)
   return chatUsage
 }

--- a/service/src/storage/mongo.ts
+++ b/service/src/storage/mongo.ts
@@ -1,7 +1,7 @@
 import { MongoClient, ObjectId } from 'mongodb'
 import * as dotenv from 'dotenv'
-import { ChatInfo, ChatRoom, Status, UserInfo } from './model'
-import type { ChatOptions, Config } from './model'
+import { ChatInfo, ChatRoom, ChatUsage, Status, UserInfo } from './model'
+import type { ChatOptions, Config, UsageResponse } from './model'
 
 dotenv.config()
 
@@ -11,6 +11,7 @@ const chatCol = client.db('chatgpt').collection('chat')
 const roomCol = client.db('chatgpt').collection('chat_room')
 const userCol = client.db('chatgpt').collection('user')
 const configCol = client.db('chatgpt').collection('config')
+const usageCol = client.db('chatgpt').collection('chat_usage')
 
 /**
  * 插入聊天信息
@@ -39,6 +40,12 @@ export async function updateChat(chatId: string, response: string, messageId: st
     update.$set.previousResponse = previousResponse
 
   await chatCol.updateOne(query, update)
+}
+
+export async function insertChatUsage(userId: string, roomId: number, uuid: number, messageId: string, usage: UsageResponse) {
+  const chatUsage = new ChatUsage(userId, roomId, uuid, messageId, usage)
+  await usageCol.insertOne(chatUsage)
+  return chatUsage
 }
 
 export async function createChatRoom(userId: string, title: string, roomId: number) {


### PR DESCRIPTION
> 需要升级依赖 chatgpt 到 [5.2.0+](https://github.com/transitive-bullshit/chatgpt-api/releases/tag/v5.2.0)
> 这在主 Repo 遇到了[问题](https://github.com/Chanzhaoyu/chatgpt-web/commit/abc4c3ad223b8f2498ca3e01aaafeb0339ef80f8)，不过我试下来没什么发现

单独建表而不是更新在原来的 ChatInfo 表，是因为考虑到一个问题可以多次生成回答，如果都记录下来在一个 ChatInfo 中必然会有多层，对统计不友好。而单独建一个统计表也方便之后如果有需要统计每个用户的使用量，各个表的 ID 都在，应该可以链回原来表的，信息不冗余也不缺失

