### PR TITLE
聊天历史由 MongoDB 中获取

### DIFF
--- a/service/src/chatgpt/index.ts
+++ b/service/src/chatgpt/index.ts
@@ -12,6 +12,7 @@ import { getCacheConfig, getOriginConfig } from '../storage/config'
 import { sendResponse } from '../utils'
 import { isNotEmptyString } from '../utils/is'
 import type { ChatContext, ChatGPTUnofficialProxyAPIOptions, ModelConfig } from '../types'
+import { getChatByMessageId } from '../storage/mongo'
 import type { RequestOptions } from './types'
 
 const { HttpsProxyAgent } = httpsProxyAgent
@@ -45,6 +46,8 @@ export async function initApi() {
       apiKey: config.apiKey,
       completionParams: { model },
       debug: !config.apiDisableDebug,
+      messageStore: undefined,
+      getMessageById,
     }
     // increase max token limit if use gpt-4
     if (model.toLowerCase().includes('gpt-4')) {
@@ -259,6 +262,33 @@ async function setupProxy(options: ChatGPTAPIOptions | ChatGPTUnofficialProxyAPI
       }
     }
   }
+}
+
+async function getMessageById(id: string): Promise<ChatMessage | undefined> {
+  const isPrompt = id.startsWith('prompt_')
+  const chatInfo = await getChatByMessageId(isPrompt ? id.substring(7) : id)
+
+  if (chatInfo) {
+    if (isPrompt) { // prompt
+      return {
+        id,
+        conversationId: chatInfo.options.conversationId,
+        parentMessageId: chatInfo.options.parentMessageId,
+        role: 'user',
+        text: chatInfo.prompt,
+      }
+    }
+    else {
+      return { // completion
+        id,
+        conversationId: chatInfo.options.conversationId,
+        parentMessageId: `prompt_${id}`, // parent message is the prompt
+        role: 'assistant',
+        text: chatInfo.response,
+      }
+    }
+  }
+  else { return undefined }
 }
 
 initApi()

--- a/service/src/storage/mongo.ts
+++ b/service/src/storage/mongo.ts
@@ -15,6 +15,7 @@ const usageCol = client.db('chatgpt').collection('chat_usage')
 
 /**
  * 插入聊天信息
+ * @param uuid
  * @param text 内容 prompt or response
  * @param roomId
  * @param options
@@ -28,6 +29,10 @@ export async function insertChat(uuid: number, text: string, roomId: number, opt
 
 export async function getChat(roomId: number, uuid: number) {
   return await chatCol.findOne({ roomId, uuid }) as ChatInfo
+}
+
+export async function getChatByMessageId(messageId: string) {
+  return await chatCol.findOne({ 'options.messageId': messageId }) as ChatInfo
 }
 
 export async function updateChat(chatId: string, response: string, messageId: string, usage: UsageResponse, previousResponse?: []) {


### PR DESCRIPTION
重启服务后上下文在提问中得以保存

同时关掉 api 依赖库中的缓存以减少长时间使用后的内存占用

---

可能带来的问题是上下文条数很多时多次读取 MongoDB 数据库，会加大数据库压力和增大延迟，可以做的优化是做一层小缓存

---

只试过 API 走 GPT 3.5，accessToken 方式需要测试