### PR TITLE
fix: Failed to resolve component NButton

### DIFF
--- a/src/views/chat/components/Message/index.vue
+++ b/src/views/chat/components/Message/index.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import { computed, ref } from 'vue'
-import { NButtonGroup, NDropdown, NPopover, NSpace, useMessage } from 'naive-ui'
+import { NButton, NButtonGroup, NDropdown, NPopover, NSpace, useMessage } from 'naive-ui'
 import AvatarComponent from './Avatar.vue'
 import TextComponent from './Text.vue'
 import { SvgIcon } from '@/components/common'


### PR DESCRIPTION
fix: https://github.com/Kerwin1202/chatgpt-web/issues/252

import 少了NButton，导致console warnnig

可能因为有import NButtonGroup，vscode并未报错