### PR TITLE
feat: refactor mail template and add link address for copy

### DIFF
--- a/service/src/utils/templates/mail.admin.template.html
+++ b/service/src/utils/templates/mail.admin.template.html
@@ -8,29 +8,30 @@
 			text-align: center;
 		"
 	>
-		<div class="main-wrapper">
+		<div
+			class="main-wrapper"
+			style="display: flex; flex-flow: column nowrap; justify-content: center"
+		>
 			<!-- top area start -->
-			<div
-				class="header-wrapper"
-				style="height: 10em; background: #fcc; justify-content: center"
-			></div>
-			<div
-				class="avatar"
-				style="
-					background-color: #eee;
-					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
-					width: 10em;
-					height: 10em;
-					margin: -5em auto 1em;
-					background-size: cover;
-					border-radius: 50%;
-					border: 0.25em solid white;
-				"
-			></div>
+			<div class="header-wrapper" style="height: 10em; background: #fcc">
+				<div
+					class="avatar"
+					style="
+						background-color: #eee;
+						background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+						width: 10em;
+						height: 10em;
+						margin: 5em auto 0;
+						background-size: cover;
+						border-radius: 50%;
+						border: 0.25em solid white;
+					"
+				></div>
+			</div>
 			<div
 				class="article-title"
 				style="
-					margin: 0 auto;
+					margin: 6em auto 0;
 					font-weight: bold;
 					line-height: 2;
 					text-align: center;
@@ -75,21 +76,17 @@
 							style="
 								display: inline-block;
 								height: 3em;
+								line-height: 3em;
 								min-width: 8em;
 								background: #fcc;
+								color: #c33;
 								border-radius: 3em;
 								margin: 2em auto;
 							"
 						>
 							<a
 								target="_blank"
-								style="
-									height: 3em;
-									line-height: 3em;
-									color: #c33;
-									text-decoration: none;
-									padding: 0 1.5em;
-								"
+								style="color: #c33; text-decoration: none; padding: 0 1.5em"
 								href="${VERIFY_URL}"
 							>
 								点我开通
@@ -99,11 +96,19 @@
 
 					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
 
-					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+					<div style="color: #888; font-size: 0.8em">
 						<div>或者复制链接，并去浏览器打开</div>
-						<a href="${VERIFY_URL}" style="text-decoration: none; color: #888"
-							>${VERIFY_URL}</a
-						>
+						<div style="font-family: monospace">
+							<a
+								href="${VERIFY_URL}"
+								style="
+									text-decoration: none;
+									color: #888;
+									font-family: monospace;
+								"
+								>${VERIFY_URL}</a
+							>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/service/src/utils/templates/mail.admin.template.html
+++ b/service/src/utils/templates/mail.admin.template.html
@@ -1,139 +1,119 @@
 <html>
-  <head> </head>
-  <body>
-    <div class="page flex-col">
-      <div class="box_3 flex-col" style="
-        display: flex;
-        position: relative;
-        width: 100%;
-        height: 206px;
-        background: #ef859d2e;
-        top: 0;
-        left: 0;
-        justify-content: center;
-      ">
-        <div class="section_1 flex-col" style="
-        background-image: url(&quot;https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg&quot;);
-        position: absolute;
-        width: 152px;
-        height: 152px;
-        display: flex;
-        top: 130px;
-        background-size: cover;
-        border-radius: 50%;
-        margin: 10px;
-      "></div>
-      </div>
-      <div class="box_4 flex-col" style="
-        margin-top: 92px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      ">
-        <div class="text-group_5 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin: 0 20px;
-      ">
-          <span class="text_1" style="
-        font-size: 26px;
-        font-family: PingFang-SC-Bold, PingFang-SC;
-        font-weight: bold;
-        color: #000000;
-        line-height: 37px;
-        text-align: center;
-        ">
-            <target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a> 账号申请
-          </span>
+	<head> </head>
 
-          <div class="box_2 flex-row" style="
-        margin: 0 20px;
-        min-height: 128px;
-        background: #F7F7F7;
-        border-radius: 12px;
-        margin-top: 34px;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 32px 16px;
-        width: calc(100% - 40px);
-      ">
+	<body
+		style="
+			font-family: -apple-system, 'microsoft yahei', sans-serif;
+			font-size: 16px;
+			text-align: center;
+		"
+	>
+		<div class="main-wrapper">
+			<!-- top area start -->
+			<div
+				class="header-wrapper"
+				style="height: 10em; background: #fcc; justify-content: center"
+			></div>
+			<div
+				class="avatar"
+				style="
+					background-color: #eee;
+					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+					width: 10em;
+					height: 10em;
+					margin: -5em auto 1em;
+					background-size: cover;
+					border-radius: 50%;
+					border: 0.25em solid white;
+				"
+			></div>
+			<div
+				class="article-title"
+				style="
+					margin: 0 auto;
+					font-weight: bold;
+					line-height: 2;
+					text-align: center;
+					color: #06f;
+				"
+			>
+				${SITE_TITLE} 账号申请
+			</div>
+			<!-- top area end -->
 
-            <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-        margin-bottom: 16px;
-      ">
-              <hr>
-              <span class="text_3" style=" font-family: Arial, sans-serif; font-size: 16px; color: #333;">
-                <h1 style="color: #0088cc;">
-                  账号申请邮箱：${TO_MAIL}，账号开通链接为（12小时内有效）：
-              </span>
-            </div>
-            <hr style="
-          display: flex;
-          position: relative;
-          border: 1px dashed #ef859d2e;
-          box-sizing: content-box;
-          height: 0px;
-          overflow: visible;
-          width: 100%;
-      ">
-            <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-      ">
-              <hr>
-              </h1>
-              <p style="margin-top: 20px;">
-                请点击以下按钮进行开通：
-                <span class="text_4" style="
-      margin-top: 6px;
-      margin-right: 22px;
-      font-size: 16px;
-      font-family: PingFangSC-Regular, PingFang SC;
-      font-weight: 400;
-      color: #000000;
-      line-height: 22px;
-      "></span>
-            </div>
+			<!-- content area start -->
+			<div
+				class="content-wrapper"
+				style="
+					width: 100%;
+					padding: 2em;
+					box-sizing: border-box;
+					overflow: hidden;
+				"
+			>
+				<div
+					class="content gray-box"
+					style="
+						min-height: 8em;
+						background: #8881;
+						border-radius: 2em;
+						margin-top: 2em;
+						padding: 2em;
+						box-sizing: border-box;
+					"
+				>
+					<div style="text-align: center; color: #06f; font-size: 1.5em">
+            账号申请邮箱：${TO_MAIL}，这是您的账号开通链接 (12小时内有效)
+					</div>
 
-            <a target="_blank" class="text-wrapper_2 flex-col" style="
-        min-width: 106px;
-        height: 38px;
-        background: #ef859d38;
-        border-radius: 32px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-decoration: none;
-        margin: auto;
-        margin-top: 32px;
-      " href="${VERIFY_URL}">
-              <span class="text_5" style="
-        color: #DB214B;
-      ">点我开通</span>
-            </a>
-          </div>
-          <div class="text-group_6 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin-top: 34px;
-      ">
-            <span class="text_6" style="
-        height: 17px;
-        font-size: 12px;
-        font-family: PingFangSC-Regular, PingFang SC;
-        font-weight: 400;
-        color: #00000045;
-        line-height: 17px;
-      ">此邮件由服务器自动发出，直接回复无效。</span>
-          </div>
-        </div>
-      </div>
-  </body>
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="text-align: center">
+						<div>请点击以下按钮进行开通</div>
+
+						<div
+							style="
+								display: inline-block;
+								height: 3em;
+								min-width: 8em;
+								background: #fcc;
+								border-radius: 3em;
+								margin: 2em auto;
+							"
+						>
+							<a
+								target="_blank"
+								style="
+									height: 3em;
+									line-height: 3em;
+									color: #c33;
+									text-decoration: none;
+									padding: 0 1.5em;
+								"
+								href="${VERIFY_URL}"
+							>
+								点我开通
+							</a>
+						</div>
+					</div>
+
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+						<div>或者复制链接，并去浏览器打开</div>
+						<a href="${VERIFY_URL}" style="text-decoration: none; color: #888"
+							>${VERIFY_URL}</a
+						>
+					</div>
+				</div>
+			</div>
+			<!-- content area end -->
+
+			<!-- footer start -->
+			<div class="footer" style="margin: 2rem; color: #999; font-size: 0.8em">
+				此邮件由服务器自动发出，直接回复无效。
+			</div>
+			<!-- footer end -->
+		</div>
+	</body>
 </html>

--- a/service/src/utils/templates/mail.notice.template.html
+++ b/service/src/utils/templates/mail.notice.template.html
@@ -8,29 +8,30 @@
 			text-align: center;
 		"
 	>
-		<div class="main-wrapper">
+		<div
+			class="main-wrapper"
+			style="display: flex; flex-flow: column nowrap; justify-content: center"
+		>
 			<!-- top area start -->
-			<div
-				class="header-wrapper"
-				style="height: 10em; background: #fcc; justify-content: center"
-			></div>
-			<div
-				class="avatar"
-				style="
-					background-color: #eee;
-					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
-					width: 10em;
-					height: 10em;
-					margin: -5em auto 1em;
-					background-size: cover;
-					border-radius: 50%;
-					border: 0.25em solid white;
-				"
-			></div>
+			<div class="header-wrapper" style="height: 10em; background: #fcc">
+				<div
+					class="avatar"
+					style="
+						background-color: #eee;
+						background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+						width: 10em;
+						height: 10em;
+						margin: 5em auto 0;
+						background-size: cover;
+						border-radius: 50%;
+						border: 0.25em solid white;
+					"
+				></div>
+			</div>
 			<div
 				class="article-title"
 				style="
-					margin: 0 auto;
+					margin: 6em auto 0;
 					font-weight: bold;
 					line-height: 2;
 					text-align: center;
@@ -75,21 +76,17 @@
 							style="
 								display: inline-block;
 								height: 3em;
+								line-height: 3em;
 								min-width: 8em;
 								background: #fcc;
+								color: #c33;
 								border-radius: 3em;
 								margin: 2em auto;
 							"
 						>
 							<a
 								target="_blank"
-								style="
-									height: 3em;
-									line-height: 3em;
-									color: #c33;
-									text-decoration: none;
-									padding: 0 1.5em;
-								"
+								style="color: #c33; text-decoration: none; padding: 0 1.5em"
 								href="${SITE_DOMAIN}"
 							>
 								点我登陆
@@ -99,11 +96,19 @@
 
 					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
 
-					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+					<div style="color: #888; font-size: 0.8em">
 						<div>或者复制链接，并去浏览器打开</div>
-						<a href="${SITE_DOMAIN}" style="text-decoration: none; color: #888"
-							>${SITE_DOMAIN}</a
-						>
+						<div style="font-family: monospace">
+							<a
+								href="${SITE_DOMAIN}"
+								style="
+									text-decoration: none;
+									color: #888;
+									font-family: monospace;
+								"
+								>${SITE_DOMAIN}</a
+							>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/service/src/utils/templates/mail.notice.template.html
+++ b/service/src/utils/templates/mail.notice.template.html
@@ -1,141 +1,119 @@
 <html>
-  <head> </head>
-  <body>
-    <div class="page flex-col">
-      <div class="box_3 flex-col" style="
-        display: flex;
-        position: relative;
-        width: 100%;
-        height: 206px;
-        background: #ef859d2e;
-        top: 0;
-        left: 0;
-        justify-content: center;
-      ">
-        <div class="section_1 flex-col" style="
-        background-image: url(&quot;https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg&quot;);
-        position: absolute;
-        width: 152px;
-        height: 152px;
-        display: flex;
-        top: 130px;
-        background-size: cover;
-        border-radius: 50%;
-        margin: 10px;
-      "></div>
-      </div>
-      <div class="box_4 flex-col" style="
-        margin-top: 92px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      ">
-        <div class="text-group_5 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin: 0 20px;
-      ">
-          <span class="text_1" style="
-        font-size: 26px;
-        font-family: PingFang-SC-Bold, PingFang-SC;
-        font-weight: bold;
-        color: #000000;
-        line-height: 37px;
-        text-align: center;
-        ">
-            <target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a> 账号开通
-          </span>
+	<head> </head>
 
-          <div class="box_2 flex-row" style="
-        margin: 0 20px;
-        min-height: 128px;
-        background: #F7F7F7;
-        border-radius: 12px;
-        margin-top: 34px;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 32px 16px;
-        width: calc(100% - 40px);
-      ">
+	<body
+		style="
+			font-family: -apple-system, 'microsoft yahei', sans-serif;
+			font-size: 16px;
+			text-align: center;
+		"
+	>
+		<div class="main-wrapper">
+			<!-- top area start -->
+			<div
+				class="header-wrapper"
+				style="height: 10em; background: #fcc; justify-content: center"
+			></div>
+			<div
+				class="avatar"
+				style="
+					background-color: #eee;
+					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+					width: 10em;
+					height: 10em;
+					margin: -5em auto 1em;
+					background-size: cover;
+					border-radius: 50%;
+					border: 0.25em solid white;
+				"
+			></div>
+			<div
+				class="article-title"
+				style="
+					margin: 0 auto;
+					font-weight: bold;
+					line-height: 2;
+					text-align: center;
+					color: #06f;
+				"
+			>
+				${SITE_TITLE} 账号开通
+			</div>
+			<!-- top area end -->
 
-            <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-        margin-bottom: 16px;
-      ">
-              <hr>
-              <span class="text_3" style=" font-family: Arial, sans-serif; font-size: 16px; color: #333;">
-                <h1 style="color: #0088cc;">
-                  感谢您使用
-                  <a target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a>，
-									您的邮箱账号已开通：
-              </span>
-            </div>
-            <hr style="
-          display: flex;
-          position: relative;
-          border: 1px dashed #ef859d2e;
-          box-sizing: content-box;
-          height: 0px;
-          overflow: visible;
-          width: 100%;
-      ">
-            <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-      ">
-              <hr>
-              </h1>
-              <p style="margin-top: 20px;">
-                请点击以下按钮进行登录：
-                <span class="text_4" style="
-      margin-top: 6px;
-      margin-right: 22px;
-      font-size: 16px;
-      font-family: PingFangSC-Regular, PingFang SC;
-      font-weight: 400;
-      color: #000000;
-      line-height: 22px;
-      "></span>
-            </div>
+			<!-- content area start -->
+			<div
+				class="content-wrapper"
+				style="
+					width: 100%;
+					padding: 2em;
+					box-sizing: border-box;
+					overflow: hidden;
+				"
+			>
+				<div
+					class="content gray-box"
+					style="
+						min-height: 8em;
+						background: #8881;
+						border-radius: 2em;
+						margin-top: 2em;
+						padding: 2em;
+						box-sizing: border-box;
+					"
+				>
+					<div style="text-align: center; color: #06f; font-size: 1.5em">
+						感谢您使用 ${SITE_TITLE}， 您的邮箱账号已开通
+					</div>
 
-            <a target="_blank" class="text-wrapper_2 flex-col" style="
-        min-width: 106px;
-        height: 38px;
-        background: #ef859d38;
-        border-radius: 32px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-decoration: none;
-        margin: auto;
-        margin-top: 32px;
-      " href="${SITE_DOMAIN}">
-              <span class="text_5" style="
-        color: #DB214B;
-      ">点我登录</span>
-            </a>
-          </div>
-          <div class="text-group_6 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin-top: 34px;
-      ">
-            <span class="text_6" style="
-        height: 17px;
-        font-size: 12px;
-        font-family: PingFangSC-Regular, PingFang SC;
-        font-weight: 400;
-        color: #00000045;
-        line-height: 17px;
-      ">此邮件由服务器自动发出，直接回复无效。</span>
-          </div>
-        </div>
-      </div>
-  </body>
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="text-align: center">
+						<div>请点击以下按钮进行登陆</div>
+
+						<div
+							style="
+								display: inline-block;
+								height: 3em;
+								min-width: 8em;
+								background: #fcc;
+								border-radius: 3em;
+								margin: 2em auto;
+							"
+						>
+							<a
+								target="_blank"
+								style="
+									height: 3em;
+									line-height: 3em;
+									color: #c33;
+									text-decoration: none;
+									padding: 0 1.5em;
+								"
+								href="${SITE_DOMAIN}"
+							>
+								点我登陆
+							</a>
+						</div>
+					</div>
+
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+						<div>或者复制链接，并去浏览器打开</div>
+						<a href="${SITE_DOMAIN}" style="text-decoration: none; color: #888"
+							>${SITE_DOMAIN}</a
+						>
+					</div>
+				</div>
+			</div>
+			<!-- content area end -->
+
+			<!-- footer start -->
+			<div class="footer" style="margin: 2rem; color: #999; font-size: 0.8em">
+				此邮件由服务器自动发出，直接回复无效。
+			</div>
+			<!-- footer end -->
+		</div>
+	</body>
 </html>

--- a/service/src/utils/templates/mail.resetpassword.template.html
+++ b/service/src/utils/templates/mail.resetpassword.template.html
@@ -8,29 +8,30 @@
 			text-align: center;
 		"
 	>
-		<div class="main-wrapper">
+		<div
+			class="main-wrapper"
+			style="display: flex; flex-flow: column nowrap; justify-content: center"
+		>
 			<!-- top area start -->
-			<div
-				class="header-wrapper"
-				style="height: 10em; background: #fcc; justify-content: center"
-			></div>
-			<div
-				class="avatar"
-				style="
-					background-color: #eee;
-					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
-					width: 10em;
-					height: 10em;
-					margin: -5em auto 1em;
-					background-size: cover;
-					border-radius: 50%;
-					border: 0.25em solid white;
-				"
-			></div>
+			<div class="header-wrapper" style="height: 10em; background: #fcc">
+				<div
+					class="avatar"
+					style="
+						background-color: #eee;
+						background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+						width: 10em;
+						height: 10em;
+						margin: 5em auto 0;
+						background-size: cover;
+						border-radius: 50%;
+						border: 0.25em solid white;
+					"
+				></div>
+			</div>
 			<div
 				class="article-title"
 				style="
-					margin: 0 auto;
+					margin: 6em auto 0;
 					font-weight: bold;
 					line-height: 2;
 					text-align: center;
@@ -75,21 +76,17 @@
 							style="
 								display: inline-block;
 								height: 3em;
+								line-height: 3em;
 								min-width: 8em;
 								background: #fcc;
+								color: #c33;
 								border-radius: 3em;
 								margin: 2em auto;
 							"
 						>
 							<a
 								target="_blank"
-								style="
-									height: 3em;
-									line-height: 3em;
-									color: #c33;
-									text-decoration: none;
-									padding: 0 1.5em;
-								"
+								style="color: #c33; text-decoration: none; padding: 0 1.5em"
 								href="${VERIFY_URL}"
 							>
 								重置密码
@@ -99,11 +96,19 @@
 
 					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
 
-					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+					<div style="color: #888; font-size: 0.8em">
 						<div>或者复制链接，并去浏览器打开</div>
-						<a href="${VERIFY_URL}" style="text-decoration: none; color: #888"
-							>${VERIFY_URL}</a
-						>
+						<div style="font-family: monospace">
+							<a
+								href="${VERIFY_URL}"
+								style="
+									text-decoration: none;
+									color: #888;
+									font-family: monospace;
+								"
+								>${VERIFY_URL}</a
+							>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/service/src/utils/templates/mail.resetpassword.template.html
+++ b/service/src/utils/templates/mail.resetpassword.template.html
@@ -1,144 +1,119 @@
 <html>
+	<head> </head>
 
-<head> </head>
+	<body
+		style="
+			font-family: -apple-system, 'microsoft yahei', sans-serif;
+			font-size: 16px;
+			text-align: center;
+		"
+	>
+		<div class="main-wrapper">
+			<!-- top area start -->
+			<div
+				class="header-wrapper"
+				style="height: 10em; background: #fcc; justify-content: center"
+			></div>
+			<div
+				class="avatar"
+				style="
+					background-color: #eee;
+					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+					width: 10em;
+					height: 10em;
+					margin: -5em auto 1em;
+					background-size: cover;
+					border-radius: 50%;
+					border: 0.25em solid white;
+				"
+			></div>
+			<div
+				class="article-title"
+				style="
+					margin: 0 auto;
+					font-weight: bold;
+					line-height: 2;
+					text-align: center;
+					color: #06f;
+				"
+			>
+				${SITE_TITLE} 重置密码
+			</div>
+			<!-- top area end -->
 
-<body>
-  <div class="page flex-col">
-    <div class="box_3 flex-col" style="
-        display: flex;
-        position: relative;
-        width: 100%;
-        height: 206px;
-        background: #ef859d2e;
-        top: 0;
-        left: 0;
-        justify-content: center;
-      ">
-      <div class="section_1 flex-col" style="
-        background-image: url(&quot;https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg&quot;);
-        position: absolute;
-        width: 152px;
-        height: 152px;
-        display: flex;
-        top: 130px;
-        background-size: cover;
-        border-radius: 50%;
-        margin: 10px;
-      "></div>
-    </div>
-    <div class="box_4 flex-col" style="
-        margin-top: 92px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      ">
-      <div class="text-group_5 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin: 0 20px;
-      ">
-        <span class="text_1" style="
-        font-size: 26px;
-        font-family: PingFang-SC-Bold, PingFang-SC;
-        font-weight: bold;
-        color: #000000;
-        line-height: 37px;
-        text-align: center;
-        ">
-          <target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a> 重置密码
-        </span>
+			<!-- content area start -->
+			<div
+				class="content-wrapper"
+				style="
+					width: 100%;
+					padding: 2em;
+					box-sizing: border-box;
+					overflow: hidden;
+				"
+			>
+				<div
+					class="content gray-box"
+					style="
+						min-height: 8em;
+						background: #8881;
+						border-radius: 2em;
+						margin-top: 2em;
+						padding: 2em;
+						box-sizing: border-box;
+					"
+				>
+					<div style="text-align: center; color: #06f; font-size: 1.5em">
+						感谢您使用 ${SITE_TITLE}， 这是您的重置密码链接 (12小时内有效)
+					</div>
 
-        <div class="box_2 flex-row" style="
-        margin: 0 20px;
-        min-height: 128px;
-        background: #F7F7F7;
-        border-radius: 12px;
-        margin-top: 34px;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 32px 16px;
-        width: calc(100% - 40px);
-      ">
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
 
-          <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-        margin-bottom: 16px;
-      ">
-            <hr>
-            <span class="text_3" style=" font-family: Arial, sans-serif; font-size: 16px; color: #333;">
-              <h1 style="color: #0088cc;">
-                感谢您使用
-                <a target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a>，
-                您的重置密码链接为（12小时内有效）：
-            </span>
-          </div>
-          <hr style="
-          display: flex;
-          position: relative;
-          border: 1px dashed #ef859d2e;
-          box-sizing: content-box;
-          height: 0px;
-          overflow: visible;
-          width: 100%;
-      ">
-          <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-      ">
-            <hr>
-            </h1>
-            <p style="margin-top: 20px;">
-              请点击以下按钮进行重置密码：
-              <span class="text_4" style="
-      margin-top: 6px;
-      margin-right: 22px;
-      font-size: 16px;
-      font-family: PingFangSC-Regular, PingFang SC;
-      font-weight: 400;
-      color: #000000;
-      line-height: 22px;
-      "></span>
-          </div>
+					<div style="text-align: center">
+						<div>请点击以下按钮进行重置密码</div>
 
-          <a target="_blank" class="text-wrapper_2 flex-col" style="
-        min-width: 106px;
-        height: 38px;
-        background: #ef859d38;
-        border-radius: 32px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-decoration: none;
-        margin: auto;
-        margin-top: 32px;
-      " href="${VERIFY_URL}">
-            <span class="text_5" style="
-        color: #DB214B;
-      ">重置密码</span>
-          </a>
-        </div>
-        <div class="text-group_6 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin-top: 34px;
-      ">
-          <span class="text_6" style="
-        height: 17px;
-        font-size: 12px;
-        font-family: PingFangSC-Regular, PingFang SC;
-        font-weight: 400;
-        color: #00000045;
-        line-height: 17px;
-      ">此邮件由服务器自动发出，直接回复无效。</span>
-        </div>
-      </div>
-    </div>
-</body>
+						<div
+							style="
+								display: inline-block;
+								height: 3em;
+								min-width: 8em;
+								background: #fcc;
+								border-radius: 3em;
+								margin: 2em auto;
+							"
+						>
+							<a
+								target="_blank"
+								style="
+									height: 3em;
+									line-height: 3em;
+									color: #c33;
+									text-decoration: none;
+									padding: 0 1.5em;
+								"
+								href="${VERIFY_URL}"
+							>
+								重置密码
+							</a>
+						</div>
+					</div>
 
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+						<div>或者复制链接，并去浏览器打开</div>
+						<a href="${VERIFY_URL}" style="text-decoration: none; color: #888"
+							>${VERIFY_URL}</a
+						>
+					</div>
+				</div>
+			</div>
+			<!-- content area end -->
+
+			<!-- footer start -->
+			<div class="footer" style="margin: 2rem; color: #999; font-size: 0.8em">
+				此邮件由服务器自动发出，直接回复无效。
+			</div>
+			<!-- footer end -->
+		</div>
+	</body>
 </html>

--- a/service/src/utils/templates/mail.template.html
+++ b/service/src/utils/templates/mail.template.html
@@ -1,141 +1,119 @@
 <html>
-  <head> </head>
-  <body>
-    <div class="page flex-col">
-      <div class="box_3 flex-col" style="
-        display: flex;
-        position: relative;
-        width: 100%;
-        height: 206px;
-        background: #ef859d2e;
-        top: 0;
-        left: 0;
-        justify-content: center;
-      ">
-        <div class="section_1 flex-col" style="
-        background-image: url(&quot;https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg&quot;);
-        position: absolute;
-        width: 152px;
-        height: 152px;
-        display: flex;
-        top: 130px;
-        background-size: cover;
-        border-radius: 50%;
-        margin: 10px;
-      "></div>
-      </div>
-      <div class="box_4 flex-col" style="
-        margin-top: 92px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      ">
-        <div class="text-group_5 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin: 0 20px;
-      ">
-          <span class="text_1" style="
-        font-size: 26px;
-        font-family: PingFang-SC-Bold, PingFang-SC;
-        font-weight: bold;
-        color: #000000;
-        line-height: 37px;
-        text-align: center;
-        ">
-            <target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a> 账号验证
-          </span>
+	<head> </head>
 
-          <div class="box_2 flex-row" style="
-        margin: 0 20px;
-        min-height: 128px;
-        background: #F7F7F7;
-        border-radius: 12px;
-        margin-top: 34px;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 32px 16px;
-        width: calc(100% - 40px);
-      ">
+	<body
+		style="
+			font-family: -apple-system, 'microsoft yahei', sans-serif;
+			font-size: 16px;
+			text-align: center;
+		"
+	>
+		<div class="main-wrapper">
+			<!-- top area start -->
+			<div
+				class="header-wrapper"
+				style="height: 10em; background: #fcc; justify-content: center"
+			></div>
+			<div
+				class="avatar"
+				style="
+					background-color: #eee;
+					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+					width: 10em;
+					height: 10em;
+					margin: -5em auto 1em;
+					background-size: cover;
+					border-radius: 50%;
+					border: 0.25em solid white;
+				"
+			></div>
+			<div
+				class="article-title"
+				style="
+					margin: 0 auto;
+					font-weight: bold;
+					line-height: 2;
+					text-align: center;
+					color: #06f;
+				"
+			>
+				${SITE_TITLE} 账号验证
+			</div>
+			<!-- top area end -->
 
-            <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-        margin-bottom: 16px;
-      ">
-              <hr>
-              <span class="text_3" style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">
-                <h1 style="color: #0088cc;">
-                  感谢您使用
-                  <a target="_blank" style="text-decoration: none; color: #0088cc;">${SITE_TITLE}</a>，
-                    您的邮箱验证链接为（12小时内有效）：
-              </span>
-            </div>
-            <hr style="
-          display: flex;
-          position: relative;
-          border: 1px dashed #ef859d2e;
-          box-sizing: content-box;
-          height: 0px;
-          overflow: visible;
-          width: 100%;
-      ">
-            <div class="text-wrapper_4 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        margin-left: 30px;
-      ">
-              <hr>
-              </h1>
-              <p style="margin-top: 20px;">
-                请点击以下按钮进行验证：
-                <span class="text_4" style="
-      margin-top: 6px;
-      margin-right: 22px;
-      font-size: 16px;
-      font-family: PingFangSC-Regular, PingFang SC;
-      font-weight: 400;
-      color: #000000;
-      line-height: 22px;
-      "></span>
-            </div>
+			<!-- content area start -->
+			<div
+				class="content-wrapper"
+				style="
+					width: 100%;
+					padding: 2em;
+					box-sizing: border-box;
+					overflow: hidden;
+				"
+			>
+				<div
+					class="content gray-box"
+					style="
+						min-height: 8em;
+						background: #8881;
+						border-radius: 2em;
+						margin-top: 2em;
+						padding: 2em;
+						box-sizing: border-box;
+					"
+				>
+					<div style="text-align: center; color: #06f; font-size: 1.5em">
+						感谢您使用 ${SITE_TITLE}， 这是您的邮箱验证链接 (12小时内有效)
+					</div>
 
-            <a target="_blank" class="text-wrapper_2 flex-col" style="
-        min-width: 106px;
-        height: 38px;
-        background: #ef859d38;
-        border-radius: 32px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-decoration: none;
-        margin: auto;
-        margin-top: 32px;
-      " href="${VERIFY_URL}">
-              <span class="text_5" style="
-        color: #DB214B;
-      ">点我验证</span>
-            </a>
-          </div>
-          <div class="text-group_6 flex-col justify-between" style="
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        margin-top: 34px;
-      ">
-            <span class="text_6" style="
-        height: 17px;
-        font-size: 12px;
-        font-family: PingFangSC-Regular, PingFang SC;
-        font-weight: 400;
-        color: #00000045;
-        line-height: 17px;
-      ">此邮件由服务器自动发出，直接回复无效。</span>
-          </div>
-        </div>
-      </div>
-  </body>
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="text-align: center">
+						<div>请点击以下按钮进行验证</div>
+
+						<div
+							style="
+								display: inline-block;
+								height: 3em;
+								min-width: 8em;
+								background: #fcc;
+								border-radius: 3em;
+								margin: 2em auto;
+							"
+						>
+							<a
+								target="_blank"
+								style="
+									height: 3em;
+									line-height: 3em;
+									color: #c33;
+									text-decoration: none;
+									padding: 0 1.5em;
+								"
+								href="${VERIFY_URL}"
+							>
+								点我验证
+							</a>
+						</div>
+					</div>
+
+					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
+
+					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+						<div>或者复制链接，并去浏览器打开</div>
+						<a href="${VERIFY_URL}" style="text-decoration: none; color: #888"
+							>${VERIFY_URL}</a
+						>
+					</div>
+				</div>
+			</div>
+			<!-- content area end -->
+
+			<!-- footer start -->
+			<div class="footer" style="margin: 2rem; color: #999; font-size: 0.8em">
+				此邮件由服务器自动发出，直接回复无效。
+			</div>
+			<!-- footer end -->
+		</div>
+	</body>
 </html>

--- a/service/src/utils/templates/mail.template.html
+++ b/service/src/utils/templates/mail.template.html
@@ -8,29 +8,30 @@
 			text-align: center;
 		"
 	>
-		<div class="main-wrapper">
+		<div
+			class="main-wrapper"
+			style="display: flex; flex-flow: column nowrap; justify-content: center"
+		>
 			<!-- top area start -->
-			<div
-				class="header-wrapper"
-				style="height: 10em; background: #fcc; justify-content: center"
-			></div>
-			<div
-				class="avatar"
-				style="
-					background-color: #eee;
-					background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
-					width: 10em;
-					height: 10em;
-					margin: -5em auto 1em;
-					background-size: cover;
-					border-radius: 50%;
-					border: 0.25em solid white;
-				"
-			></div>
+			<div class="header-wrapper" style="height: 10em; background: #fcc">
+				<div
+					class="avatar"
+					style="
+						background-color: #eee;
+						background-image: url('https://ghproxy.com/https://raw.githubusercontent.com/Chanzhaoyu/chatgpt-web/main/src/assets/avatar.jpg');
+						width: 10em;
+						height: 10em;
+						margin: 5em auto 0;
+						background-size: cover;
+						border-radius: 50%;
+						border: 0.25em solid white;
+					"
+				></div>
+			</div>
 			<div
 				class="article-title"
 				style="
-					margin: 0 auto;
+					margin: 6em auto 0;
 					font-weight: bold;
 					line-height: 2;
 					text-align: center;
@@ -75,21 +76,17 @@
 							style="
 								display: inline-block;
 								height: 3em;
+								line-height: 3em;
 								min-width: 8em;
 								background: #fcc;
+								color: #c33;
 								border-radius: 3em;
 								margin: 2em auto;
 							"
 						>
 							<a
 								target="_blank"
-								style="
-									height: 3em;
-									line-height: 3em;
-									color: #c33;
-									text-decoration: none;
-									padding: 0 1.5em;
-								"
+								style="color: #c33; text-decoration: none; padding: 0 1.5em"
 								href="${VERIFY_URL}"
 							>
 								点我验证
@@ -99,11 +96,19 @@
 
 					<hr style="border: 1px dashed #fcc; margin: 2em 0" />
 
-					<div style="color: #888; font-family: monospace; font-size: 0.8em">
+					<div style="color: #888; font-size: 0.8em">
 						<div>或者复制链接，并去浏览器打开</div>
-						<a href="${VERIFY_URL}" style="text-decoration: none; color: #888"
-							>${VERIFY_URL}</a
-						>
+						<div style="font-family: monospace">
+							<a
+								href="${VERIFY_URL}"
+								style="
+									text-decoration: none;
+									color: #888;
+									font-family: monospace;
+								"
+								>${VERIFY_URL}</a
+							>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/src/components/common/HoverButton/Button.vue
+++ b/src/components/common/HoverButton/Button.vue
@@ -12,7 +12,8 @@ function handleClick() {
 
 <template>
   <button
-    class="flex items-center justify-center w-10 h-10 transition rounded-full hover:bg-neutral-100 dark:hover:bg-[#414755]"
+    class="flex items-center justify-center h-10 transition hover:bg-neutral-100 dark:hover:bg-[#414755]"
+    style="flex-flow:row nowrap;min-width:2.5em;padding:.5em;border-radius:.5em;"
     @click="handleClick"
   >
     <slot />

--- a/src/views/chat/components/Header/index.vue
+++ b/src/views/chat/components/Header/index.vue
@@ -74,10 +74,11 @@ function handleShowPrompt() {
             <IconPrompt class="w-[20px] m-auto" />
           </span>
         </HoverButton>
-        <HoverButton @click="toggleUsingContext">
-          <span class="text-xl" :class="{ 'text-[#4b9e5f]': usingContext, 'text-[#a8071a]': !usingContext }">
+        <HoverButton :tooltip="usingContext ? '点击停止包含上下文' : '点击开启包含上下文'" :class="{ 'text-[#4b9e5f]': usingContext, 'text-[#a8071a]': !usingContext }" @click="toggleUsingContext">
+          <span class="text-xl">
             <SvgIcon icon="ri:chat-history-line" />
           </span>
+          <span style="margin-left:.25em">{{ usingContext ? '包含上下文' : '不含上下文' }}</span>
         </HoverButton>
         <HoverButton @click="handleExport">
           <span class="text-xl text-[#4f555e] dark:text-white">

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -683,10 +683,11 @@ onUnmounted(() => {
                 <IconPrompt class="w-[20px] m-auto" />
               </span>
             </HoverButton>
-            <HoverButton v-if="!isMobile" @click="handleToggleUsingContext">
-              <span class="text-xl" :class="{ 'text-[#4b9e5f]': usingContext, 'text-[#a8071a]': !usingContext }">
+            <HoverButton v-if="!isMobile" :tooltip="usingContext ? '点击停止包含上下文' : '点击开启包含上下文'" :class="{ 'text-[#4b9e5f]': usingContext, 'text-[#a8071a]': !usingContext }" @click="handleToggleUsingContext">
+              <span class="text-xl">
                 <SvgIcon icon="ri:chat-history-line" />
               </span>
+              <span style="margin-left:.25em">{{ usingContext ? '包含上下文' : '不含上下文' }}</span>
             </HoverButton>
             <NSelect
               style="width: 250px"


### PR DESCRIPTION
有些邮箱不支持直接点击按钮，禁用了a元素，并且无法查看href上的链接。
这样会造成使用体验中断，所以还是增加了显示URL的功能。

顺便重构了一下邮件的代码，移除了一些多余的内容。

修改后效果如下：

![image](https://github.com/Kerwin1202/chatgpt-web/assets/17139670/2de53f45-cebf-4ae7-add3-3f4787f00af8)
