### PR TITLE
chore: backend not response mongodb UpdateResult data

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -35,7 +35,7 @@
     "https-proxy-agent": "^5.0.1",
     "isomorphic-fetch": "^3.0.0",
     "jwt-decode": "^3.1.2",
-    "mongodb": "^5.1.0",
+    "mongodb": "^5.9.2",
     "node-fetch": "^3.3.0",
     "nodemailer": "^6.9.1",
     "request-ip": "^3.3.0",
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@antfu/eslint-config": "^0.35.3",
     "@types/express": "^4.17.17",
-    "@types/mongodb": "^4.0.7",
     "@types/node": "^18.14.6",
     "eslint": "^8.35.0",
     "jsonwebtoken": "^9.0.0",

--- a/service/pnpm-lock.yaml
+++ b/service/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   axios:
     specifier: ^1.3.4
@@ -35,8 +39,8 @@ dependencies:
     specifier: ^3.1.2
     version: 3.1.2
   mongodb:
-    specifier: ^5.1.0
-    version: 5.1.0
+    specifier: ^5.9.2
+    version: 5.9.2
   node-fetch:
     specifier: ^3.3.0
     version: 3.3.0
@@ -57,9 +61,6 @@ devDependencies:
   '@types/express':
     specifier: ^4.17.17
     version: 4.17.17
-  '@types/mongodb':
-    specifier: ^4.0.7
-    version: 4.0.7
   '@types/node':
     specifier: ^18.14.6
     version: 18.14.6
@@ -451,6 +452,14 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@mongodb-js/saslprep@1.1.1:
+    resolution: {integrity: sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==}
+    requiresBuild: true
+    dependencies:
+      sparse-bitfield: 3.0.3
+    dev: false
+    optional: true
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -520,17 +529,6 @@ packages:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
     dev: true
 
-  /@types/mongodb@4.0.7:
-    resolution: {integrity: sha512-lPUYPpzA43baXqnd36cZ9xxorprybxXDzteVKCPAdp14ppHtFJHnXYvNpmBvtMUTb5fKXVv6sVbzo1LHkWhJlw==}
-    deprecated: mongodb provides its own types. @types/mongodb is no longer needed.
-    dependencies:
-      mongodb: 5.1.0
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-providers'
-      - mongodb-client-encryption
-      - snappy
-    dev: true
-
   /@types/node@18.14.6:
     resolution: {integrity: sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==}
 
@@ -562,12 +560,14 @@ packages:
 
   /@types/webidl-conversions@7.0.0:
     resolution: {integrity: sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==}
+    dev: false
 
   /@types/whatwg-url@8.2.2:
     resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
     dependencies:
       '@types/node': 18.14.6
       '@types/webidl-conversions': 7.0.0
+    dev: false
 
   /@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.35.0)(typescript@4.9.5):
     resolution: {integrity: sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==}
@@ -730,8 +730,10 @@ packages:
       - supports-color
     dev: false
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -918,9 +920,10 @@ packages:
       fill-range: 7.0.1
     dev: true
 
-  /bson@5.1.0:
-    resolution: {integrity: sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A==}
+  /bson@5.5.1:
+    resolution: {integrity: sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==}
     engines: {node: '>=14.20.1'}
+    dev: false
 
   /buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1027,7 +1030,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /ci-info@3.8.0:
@@ -1082,7 +1085,7 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       atomically: 2.0.1
       debounce-fn: 5.1.2
       dot-prop: 7.2.0
@@ -2024,8 +2027,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -2298,6 +2301,7 @@ packages:
 
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
+    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2680,6 +2684,8 @@ packages:
 
   /memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+    requiresBuild: true
+    dev: false
     optional: true
 
   /merge-descriptors@1.0.1:
@@ -2777,27 +2783,35 @@ packages:
     dependencies:
       '@types/whatwg-url': 8.2.2
       whatwg-url: 11.0.0
+    dev: false
 
-  /mongodb@5.1.0:
-    resolution: {integrity: sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==}
+  /mongodb@5.9.2:
+    resolution: {integrity: sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==}
     engines: {node: '>=14.20.1'}
     peerDependencies:
-      '@aws-sdk/credential-providers': ^3.201.0
-      mongodb-client-encryption: ^2.3.0
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.0.0
+      kerberos: ^1.0.0 || ^2.0.0
+      mongodb-client-encryption: '>=2.3.0 <3'
       snappy: ^7.2.2
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      kerberos:
         optional: true
       mongodb-client-encryption:
         optional: true
       snappy:
         optional: true
     dependencies:
-      bson: 5.1.0
+      bson: 5.5.1
       mongodb-connection-string-url: 2.6.0
       socks: 2.7.1
     optionalDependencies:
-      saslprep: 1.0.3
+      '@mongodb-js/saslprep': 1.1.1
+    dev: false
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -3250,7 +3264,7 @@ packages:
     dev: true
 
   /request-ip@3.3.0:
-    resolution: {integrity: sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==, registry: https://registry.npm.taobao.org/}
+    resolution: {integrity: sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==}
     dev: false
 
   /require-from-string@2.0.2:
@@ -3302,7 +3316,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-parallel@1.2.0:
@@ -3331,14 +3345,6 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: false
-
-  /saslprep@1.0.3:
-    resolution: {integrity: sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==}
-    engines: {node: '>=6'}
-    requiresBuild: true
-    dependencies:
-      sparse-bitfield: 3.0.3
-    optional: true
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -3425,6 +3431,7 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    dev: false
 
   /socks-proxy-agent@7.0.0:
     resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
@@ -3443,6 +3450,7 @@ packages:
     dependencies:
       ip: 2.0.0
       smart-buffer: 4.2.0
+    dev: false
 
   /source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -3465,8 +3473,10 @@ packages:
 
   /sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+    requiresBuild: true
     dependencies:
       memory-pager: 1.5.0
+    dev: false
     optional: true
 
   /spdx-correct@3.1.1:
@@ -3623,6 +3633,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       punycode: 2.3.0
+    dev: false
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3700,7 +3711,7 @@ packages:
       '@esbuild-kit/core-utils': 3.1.0
       '@esbuild-kit/esm-loader': 2.5.5
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: false
 
   /type-check@0.4.0:
@@ -3836,6 +3847,7 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+    dev: false
 
   /whatwg-fetch@3.6.2:
     resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
@@ -3847,6 +3859,7 @@ packages:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
+    dev: false
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -109,8 +109,11 @@ router.post('/room-rename', auth, async (req, res) => {
   try {
     const userId = req.headers.userId as string
     const { title, roomId } = req.body as { title: string; roomId: number }
-    const room = await renameChatRoom(userId, title, roomId)
-    res.send({ status: 'Success', message: null, data: room })
+    const success = await renameChatRoom(userId, title, roomId)
+    if (success)
+      res.send({ status: 'Success', message: null, data: null })
+    else
+      res.send({ status: 'Fail', message: 'Saved Failed', data: null })
   }
   catch (error) {
     console.error(error)
@@ -171,11 +174,14 @@ router.post('/room-delete', auth, async (req, res) => {
     const userId = req.headers.userId as string
     const { roomId } = req.body as { roomId: number }
     if (!roomId || !await existsChatRoom(userId, roomId)) {
-      res.send({ status: 'Fail', message: 'Unknow room', data: null })
+      res.send({ status: 'Fail', message: 'Unknown room', data: null })
       return
     }
-    await deleteChatRoom(userId, roomId)
-    res.send({ status: 'Success', message: null })
+    const success = await deleteChatRoom(userId, roomId)
+    if (success)
+      res.send({ status: 'Success', message: null, data: null })
+    else
+      res.send({ status: 'Fail', message: 'Saved Failed', data: null })
   }
   catch (error) {
     console.error(error)
@@ -190,7 +196,6 @@ router.get('/chat-history', auth, async (req, res) => {
     const lastId = req.query.lastId as string
     if (!roomId || !await existsChatRoom(userId, roomId)) {
       res.send({ status: 'Success', message: null, data: [] })
-      // res.send({ status: 'Fail', message: 'Unknow room', data: null })
       return
     }
     const chats = await getChats(roomId, !isNotEmptyString(lastId) ? null : parseInt(lastId))
@@ -261,7 +266,6 @@ router.get('/chat-response-history', auth, async (req, res) => {
     const index = +req.query.index
     if (!roomId || !await existsChatRoom(userId, roomId)) {
       res.send({ status: 'Success', message: null, data: [] })
-      // res.send({ status: 'Fail', message: 'Unknow room', data: null })
       return
     }
     const chat = await getChat(roomId, uuid)
@@ -318,7 +322,7 @@ router.post('/chat-delete', auth, async (req, res) => {
     const userId = req.headers.userId as string
     const { roomId, uuid, inversion } = req.body as { roomId: number; uuid: number; inversion: boolean }
     if (!roomId || !await existsChatRoom(userId, roomId)) {
-      res.send({ status: 'Fail', message: 'Unknow room', data: null })
+      res.send({ status: 'Fail', message: 'Unknown room', data: null })
       return
     }
     await deleteChat(roomId, uuid, inversion)
@@ -347,7 +351,7 @@ router.post('/chat-clear', auth, async (req, res) => {
     const userId = req.headers.userId as string
     const { roomId } = req.body as { roomId: number }
     if (!roomId || !await existsChatRoom(userId, roomId)) {
-      res.send({ status: 'Fail', message: 'Unknow room', data: null })
+      res.send({ status: 'Fail', message: 'Unknown room', data: null })
       return
     }
     await clearChat(roomId)

--- a/service/src/storage/mongo.ts
+++ b/service/src/storage/mongo.ts
@@ -1,3 +1,4 @@
+import type { WithId } from 'mongodb'
 import { MongoClient, ObjectId } from 'mongodb'
 import * as dotenv from 'dotenv'
 import dayjs from 'dayjs'
@@ -12,12 +13,13 @@ const url = process.env.MONGODB_URL
 const parsedUrl = new URL(url)
 const dbName = (parsedUrl.pathname && parsedUrl.pathname !== '/') ? parsedUrl.pathname.substring(1) : 'chatgpt'
 const client = new MongoClient(url)
-const chatCol = client.db(dbName).collection('chat')
-const roomCol = client.db(dbName).collection('chat_room')
-const userCol = client.db(dbName).collection('user')
-const configCol = client.db(dbName).collection('config')
-const usageCol = client.db(dbName).collection('chat_usage')
-const keyCol = client.db(dbName).collection('key_config')
+
+const chatCol = client.db(dbName).collection<ChatInfo>('chat')
+const roomCol = client.db(dbName).collection<ChatRoom>('chat_room')
+const userCol = client.db(dbName).collection<UserInfo>('user')
+const configCol = client.db(dbName).collection<Config>('config')
+const usageCol = client.db(dbName).collection<ChatUsage>('chat_usage')
+const keyCol = client.db(dbName).collection<KeyConfig>('key_config')
 
 /**
  * 插入聊天信息
@@ -34,11 +36,11 @@ export async function insertChat(uuid: number, text: string, roomId: number, opt
 }
 
 export async function getChat(roomId: number, uuid: number) {
-  return await chatCol.findOne({ roomId, uuid }) as ChatInfo
+  return await chatCol.findOne({ roomId, uuid })
 }
 
 export async function getChatByMessageId(messageId: string) {
-  return await chatCol.findOne({ 'options.messageId': messageId }) as ChatInfo
+  return await chatCol.findOne({ 'options.messageId': messageId })
 }
 
 export async function updateChat(chatId: string, response: string, messageId: string, conversationId: string, usage: UsageResponse, previousResponse?: []) {
@@ -56,6 +58,7 @@ export async function updateChat(chatId: string, response: string, messageId: st
   }
 
   if (previousResponse)
+    // @ts-expect-error previousResponse
     update.$set.previousResponse = previousResponse
 
   await chatCol.updateOne(query, update)
@@ -72,6 +75,7 @@ export async function createChatRoom(userId: string, title: string, roomId: numb
   await roomCol.insertOne(room)
   return room
 }
+
 export async function renameChatRoom(userId: string, title: string, roomId: number) {
   const query = { userId, roomId }
   const update = {
@@ -79,13 +83,14 @@ export async function renameChatRoom(userId: string, title: string, roomId: numb
       title,
     },
   }
-  return await roomCol.updateOne(query, update)
+  const result = await roomCol.updateOne(query, update)
+  return result.modifiedCount > 0
 }
 
 export async function deleteChatRoom(userId: string, roomId: number) {
   const result = await roomCol.updateOne({ roomId, userId }, { $set: { status: Status.Deleted } })
   await clearChat(roomId)
-  return result
+  return result.modifiedCount > 0
 }
 
 export async function updateRoomPrompt(userId: string, roomId: number, prompt: string) {
@@ -133,9 +138,10 @@ export async function updateRoomChatModel(userId: string, roomId: number, chatMo
 }
 
 export async function getChatRooms(userId: string) {
-  const cursor = await roomCol.find({ userId, status: { $ne: Status.Deleted } })
+  const cursor = roomCol.find({ userId, status: { $ne: Status.Deleted } })
   const rooms = []
-  await cursor.forEach(doc => rooms.push(doc))
+  for await (const doc of cursor)
+    rooms.push(doc)
   return rooms
 }
 
@@ -158,9 +164,10 @@ export async function getChats(roomId: number, lastId?: number) {
     lastId = new Date().getTime()
   const query = { roomId, uuid: { $lt: lastId }, status: { $ne: Status.Deleted } }
   const limit = 20
-  const cursor = await chatCol.find(query).sort({ dateTime: -1 }).limit(limit)
+  const cursor = chatCol.find(query).sort({ dateTime: -1 }).limit(limit)
   const chats = []
-  await cursor.forEach(doc => chats.push(doc))
+  for await (const doc of cursor)
+    chats.push(doc)
   chats.reverse()
   return chats
 }
@@ -214,32 +221,32 @@ export async function createUser(email: string, password: string, roles?: UserRo
 }
 
 export async function updateUserInfo(userId: string, user: UserInfo) {
-  return userCol.updateOne({ _id: new ObjectId(userId) }
+  await userCol.updateOne({ _id: new ObjectId(userId) }
     , { $set: { name: user.name, description: user.description, avatar: user.avatar } })
 }
 
 export async function updateUserChatModel(userId: string, chatModel: string) {
-  return userCol.updateOne({ _id: new ObjectId(userId) }
+  await userCol.updateOne({ _id: new ObjectId(userId) }
     , { $set: { 'config.chatModel': chatModel } })
 }
 
 export async function updateUserAdvancedConfig(userId: string, config: AdvancedConfig) {
-  return userCol.updateOne({ _id: new ObjectId(userId) }
+  await userCol.updateOne({ _id: new ObjectId(userId) }
     , { $set: { advanced: config } })
 }
 
 export async function updateUser2FA(userId: string, secretKey: string) {
-  return userCol.updateOne({ _id: new ObjectId(userId) }
+  await userCol.updateOne({ _id: new ObjectId(userId) }
     , { $set: { secretKey, updateTime: new Date().toLocaleString() } })
 }
 
 export async function disableUser2FA(userId: string) {
-  return userCol.updateOne({ _id: new ObjectId(userId) }
+  await userCol.updateOne({ _id: new ObjectId(userId) }
     , { $set: { secretKey: null, updateTime: new Date().toLocaleString() } })
 }
 
 export async function updateUserPassword(userId: string, password: string) {
-  return userCol.updateOne({ _id: new ObjectId(userId) }
+  await userCol.updateOne({ _id: new ObjectId(userId) }
     , { $set: { password, updateTime: new Date().toLocaleString() } })
 }
 
@@ -250,7 +257,7 @@ export async function updateUserPasswordWithVerifyOld(userId: string, oldPasswor
 
 export async function getUser(email: string): Promise<UserInfo> {
   email = email.toLowerCase()
-  const userInfo = await userCol.findOne({ email }) as UserInfo
+  const userInfo = await userCol.findOne({ email })
   await initUserInfo(userInfo)
   return userInfo
 }
@@ -263,7 +270,8 @@ export async function getUsers(page: number, size: number): Promise<{ users: Use
   const limit = size
   const pagedCursor = cursor.skip(skip).limit(limit)
   const users: UserInfo[] = []
-  await pagedCursor.forEach(doc => users.push(doc))
+  for await (const doc of pagedCursor)
+    users.push(doc)
   users.forEach((user) => {
     initUserInfo(user)
   })
@@ -271,12 +279,12 @@ export async function getUsers(page: number, size: number): Promise<{ users: Use
 }
 
 export async function getUserById(userId: string): Promise<UserInfo> {
-  const userInfo = await userCol.findOne({ _id: new ObjectId(userId) }) as UserInfo
+  const userInfo = await userCol.findOne({ _id: new ObjectId(userId) })
   await initUserInfo(userInfo)
   return userInfo
 }
 
-async function initUserInfo(userInfo: UserInfo) {
+async function initUserInfo(userInfo: WithId<UserInfo>) {
   if (userInfo == null)
     return
   if (userInfo.config == null)
@@ -295,11 +303,11 @@ async function initUserInfo(userInfo: UserInfo) {
 
 export async function verifyUser(email: string, status: Status) {
   email = email.toLowerCase()
-  return await userCol.updateOne({ email }, { $set: { status, verifyTime: new Date().toLocaleString() } })
+  await userCol.updateOne({ email }, { $set: { status, verifyTime: new Date().toLocaleString() } })
 }
 
 export async function updateUserStatus(userId: string, status: Status) {
-  return await userCol.updateOne({ _id: new ObjectId(userId) }, { $set: { status, verifyTime: new Date().toLocaleString() } })
+  await userCol.updateOne({ _id: new ObjectId(userId) }, { $set: { status, verifyTime: new Date().toLocaleString() } })
 }
 
 export async function updateUser(userId: string, roles: UserRole[], password: string, remark?: string) {
@@ -307,10 +315,10 @@ export async function updateUser(userId: string, roles: UserRole[], password: st
   const query = { _id: new ObjectId(userId) }
   if (user.password !== password && user.password) {
     const newPassword = md5(password)
-    return await userCol.updateOne(query, { $set: { roles, verifyTime: new Date().toLocaleString(), password: newPassword, remark } })
+    await userCol.updateOne(query, { $set: { roles, verifyTime: new Date().toLocaleString(), password: newPassword, remark } })
   }
   else {
-    return await userCol.updateOne(query, { $set: { roles, verifyTime: new Date().toLocaleString(), remark } })
+    await userCol.updateOne(query, { $set: { roles, verifyTime: new Date().toLocaleString(), remark } })
   }
 }
 
@@ -398,10 +406,11 @@ export async function getUserStatisticsByDay(userId: ObjectId, start: number, en
 
 export async function getKeys(): Promise<{ keys: KeyConfig[]; total: number }> {
   const query = { status: { $ne: Status.Disabled } }
-  const cursor = await keyCol.find(query)
+  const cursor = keyCol.find(query)
   const total = await keyCol.countDocuments(query)
   const keys = []
-  await cursor.forEach(doc => keys.push(doc))
+  for await (const doc of cursor)
+    keys.push(doc)
   return { keys, total }
 }
 
@@ -414,5 +423,5 @@ export async function upsertKey(key: KeyConfig): Promise<KeyConfig> {
 }
 
 export async function updateApiKeyStatus(id: string, status: Status) {
-  return await keyCol.updateOne({ _id: new ObjectId(id) }, { $set: { status } })
+  await keyCol.updateOne({ _id: new ObjectId(id) }, { $set: { status } })
 }


### PR DESCRIPTION
避免在 接口 `/room-rename` 中将 mongodb 的更新结果 `UpdateResult` 直接返回到前端
以同样的风格应用到了其他接口上 避免可能产生类似的问题

更新了 `mongodb driver` 版本 并且替换了新版本中已弃用的方法 `cursor.forEach()`

另外 从 `mongodb` 4.x 开始 已经不再需要单独在 `devDependencies`中导入 `@types/mongodb` 了