### PR TITLE
chore: improve exit log when no set MONGODB_URL env

### DIFF
--- a/service/src/storage/mongo.ts
+++ b/service/src/storage/mongo.ts
@@ -10,9 +10,18 @@ import { getCacheConfig } from './config'
 dotenv.config()
 
 const url = process.env.MONGODB_URL
-const parsedUrl = new URL(url)
-const dbName = (parsedUrl.pathname && parsedUrl.pathname !== '/') ? parsedUrl.pathname.substring(1) : 'chatgpt'
-const client = new MongoClient(url)
+
+let client: MongoClient
+let dbName: string
+try {
+  client = new MongoClient(url)
+  const parsedUrl = new URL(url)
+  dbName = (parsedUrl.pathname && parsedUrl.pathname !== '/') ? parsedUrl.pathname.substring(1) : 'chatgpt'
+}
+catch (e) {
+  globalThis.console.error('MongoDB url invalid. please ensure set valid env MONGODB_URL.', e.message)
+  process.exit(1)
+}
 
 const chatCol = client.db(dbName).collection<ChatInfo>('chat')
 const roomCol = client.db(dbName).collection<ChatRoom>('chat_room')


### PR DESCRIPTION
Closed: #230 

```
MongoDB url invalid. please ensure set valid env MONGODB_URL. Cannot read properties of undefined (reading 'startsWith')
```

当未正确设置有效的 `MONGODB_URL` 打印友好的错误消息并退出进程。